### PR TITLE
Replace "Modified" and "Published" yes/no columns with one coloured value

### DIFF
--- a/code/VersionedDataObject.php
+++ b/code/VersionedDataObject.php
@@ -2,9 +2,6 @@
 
 class VersionedDataObject extends Versioned
 {
-    /**
-     *
-     */
     public function __construct()
     {
         parent::__construct(
@@ -14,12 +11,7 @@ class VersionedDataObject extends Versioned
             )
         );
     }
-    /**
-     * @param  null  $class
-     * @param        $extension
-     * @param        $args
-     * @return array
-     */
+
     public static function get_extra_config($class, $extension, $args)
     {
         return array(
@@ -29,8 +21,9 @@ class VersionedDataObject extends Versioned
             'searchable_fields' => array()
         );
     }
+
     /**
-     * @param $fields
+     * @param array $fields
      */
     public function updateSummaryFields(&$fields)
     {
@@ -43,12 +36,13 @@ class VersionedDataObject extends Versioned
     }
 
     /**
-     * @param $fields
+     * @param array $fields
      */
     public function updateSearchableFields(&$fields)
     {
         unset($fields['CMSPublishedState']);
     }
+
     /**
      * @return bool
      */
@@ -62,6 +56,7 @@ class VersionedDataObject extends Versioned
             return false;
         }
     }
+
     /**
      * @return bool
      */
@@ -79,12 +74,13 @@ class VersionedDataObject extends Versioned
 
         return (bool) DB::query("SELECT \"ID\" FROM \"{$table}_Live\" WHERE \"ID\" = {$this->owner->ID}")->value();
     }
+
     /**
-     * @return string - HTML
+     * @return HTMLText
      */
     public function getCMSPublishedState()
     {
-        $html = new HTMLText('PublishedIcon');
+        $html = new HTMLText('PublishedState');
 
         if ($this->isPublished()) {
             if ($this->stagesDiffer('Stage', 'Live')) {
@@ -104,20 +100,16 @@ class VersionedDataObject extends Versioned
             $colour,
             htmlentities($text)
         ));
-        
+
         return $html;
     }
-    /**
-     * @param FieldList $fields
-     */
+
     public function updateCMSFields(FieldList $fields)
     {
         $fields->removeByName('Version');
         $fields->removeByName('Versions');
     }
-    /**
-     *
-     */
+
     public function onBeforeWrite()
     {
         $fieldsIgnoredByVersioning = array('Version');

--- a/code/VersionedDataObject.php
+++ b/code/VersionedDataObject.php
@@ -37,18 +37,17 @@ class VersionedDataObject extends Versioned
         $fields = array_merge(
             $fields,
             array(
-                'isModifiedNice'  => 'Modified',
-                'isPublishedNice' => 'Published'
+                'CMSPublishedState'  => 'State'
             )
         );
     }
+
     /**
      * @param $fields
      */
     public function updateSearchableFields(&$fields)
     {
-        unset($fields['isModifiedNice']);
-        unset($fields['isPublishedNice']);
+        unset($fields['CMSPublishedState']);
     }
     /**
      * @return bool
@@ -81,26 +80,32 @@ class VersionedDataObject extends Versioned
         return (bool) DB::query("SELECT \"ID\" FROM \"{$table}_Live\" WHERE \"ID\" = {$this->owner->ID}")->value();
     }
     /**
-     * @param $value
-     * @return string
+     * @return string - HTML
      */
-    protected function getBooleanNice($value)
+    public function getCMSPublishedState()
     {
-        return $value ? 'Yes' : 'No';
-    }
-    /**
-     * @return mixed
-     */
-    public function isPublishedNice()
-    {
-        return $this->getBooleanNice($this->isPublished());
-    }
-    /**
-     * @return mixed
-     */
-    public function isModifiedNice()
-    {
-        return $this->getBooleanNice($this->stagesDiffer('Stage', 'Live'));
+        $html = new HTMLText('PublishedIcon');
+
+        if ($this->isPublished()) {
+            if ($this->stagesDiffer('Stage', 'Live')) {
+                $colour = '#1391DF';
+                $text = 'Modified';
+            } else {
+                $colour = '#18BA18';
+                $text = 'Published';
+            }
+        } else {
+            $colour = '#C00';
+            $text = 'Draft';
+        }
+
+        $html->setValue(sprintf(
+            '<span style="color: %s;">%s</span>',
+            $colour,
+            htmlentities($text)
+        ));
+        
+        return $html;
     }
     /**
      * @param FieldList $fields

--- a/code/VersionedDataObjectDetailsForm.php
+++ b/code/VersionedDataObjectDetailsForm.php
@@ -7,19 +7,14 @@ class VersionedDataObjectDetailsForm extends GridFieldDetailForm
 {
 }
 
-/**
- * Class VersionedDataObjectDetailsForm_ItemRequest
- */
 class VersionedDataObjectDetailsForm_ItemRequest extends GridFieldDetailForm_ItemRequest
 {
-    /**
-     * @var array
-     */
     private static $allowed_actions = array(
         'edit',
         'view',
         'ItemEditForm'
     );
+
     /**
      * @return Form
      */
@@ -193,6 +188,7 @@ class VersionedDataObjectDetailsForm_ItemRequest extends GridFieldDetailForm_Ite
 
         return $this->edit(Controller::curr()->getRequest());
     }
+
     /**
      * @param $data
      * @param $form


### PR DESCRIPTION
It's currently difficult to scan the published/unpublished/modified state of versioned dataobject records, as the representation is spread across two columns with "yes" and "no" values:

![Before](http://i.imgur.com/PbprUdA.png)

This PR fixes that by combining the columns into one "state" column, and using coloured text to differentiate between simplified representations of the state:

* **draft:** not published
* **modified:** published and modified
* **published:** published and not modified

![After](http://i.imgur.com/By84oD4.png)

I don't feel that it's necessary to show if a record is both unpublished and modified, since it doesn't have an impact on the live site, but others may have a different opinion about this.