### PR TITLE
Fixed bug where _Live data wouldn't become deleted with the staging data.

### DIFF
--- a/code/VersionedDataObject.php
+++ b/code/VersionedDataObject.php
@@ -133,6 +133,16 @@ class VersionedDataObject extends Versioned
         }
     }
 
+    public function onAfterDelete() {
+        parent::onBeforeDelete();
+
+        if (Versioned::current_stage() == 'Stage') {
+            VersionedReadingMode::setLiveReadingMode();
+            $this->owner->delete();
+            VersionedReadingMode::restoreOriginalReadingMode();
+        }
+    }
+
     /**
      * @param Place $fromStage
      * @param Place $toStage


### PR DESCRIPTION
Fixed bug where _Live data wouldn't become deleted with the staging data. ie. My 'ContentBlock_Live' would still have the record when the client deleted them.