### PR TITLE
FIX: Incompatibility with betterbuttons (Issue 32)

### DIFF
--- a/code/VersionedDataObjectDetailsForm.php
+++ b/code/VersionedDataObjectDetailsForm.php
@@ -43,6 +43,8 @@ class VersionedDataObjectDetailsForm_ItemRequest extends GridFieldDetailForm_Ite
         $form = parent::ItemEditForm();
         /* @var $actions FieldList */
         if ($form instanceof Form) {
+            $this->extend("updateItemEditForm", $form);
+            
             $actions = $form->Actions();
 
             $actions->replaceField(
@@ -96,9 +98,6 @@ class VersionedDataObjectDetailsForm_ItemRequest extends GridFieldDetailForm_Ite
 
                 $actions->removeByName('action_doDelete');
             }
-        
-            $this->extend("updateItemEditForm", $form);
-        
         }
 
         VersionedReadingMode::restoreOriginalReadingMode();


### PR DESCRIPTION
Better buttons replaces all buttons, removing the publish button added by ItemEditForm in VersionedDataObjectDetailsForm. 
Call extend before implementing extra actions. Fixes: https://github.com/heyday/silverstripe-versioneddataobjects/issues/32