### PR TITLE
Added a versioned delete action

### DIFF
--- a/code/VersionedGridFieldDeleteAction.php
+++ b/code/VersionedGridFieldDeleteAction.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Class VersionedGridFieldDeleteAction
+ *
+ * Extend the delete action with a versioned delete
+ */
+class VersionedGridFieldDeleteAction extends GridFieldDeleteAction
+{
+
+    /**
+     * Delete the object form both live and stage
+     *
+     * @param GridField $gridField
+     * @param string $actionName
+     * @param mixed $arguments
+     * @param array $data
+     * @throws ValidationException
+     */
+    public function handleAction(GridField $gridField, $actionName, $arguments, $data)
+    {
+        if ($item = $gridField->getList()->byID($arguments['RecordID'])) {
+            if (!$item->canDelete()) {
+                throw new ValidationException(
+                    _t('GridFieldAction_Delete.DeletePermissionsFailure', "No delete permissions"), 0);
+            }
+            $item->deleteFromStage('Live');
+            $item->delete();
+        }
+    }
+}


### PR DESCRIPTION
The GridField does not support deleting of versioned entries. This class extends the delete action to supply a delete action that also deletes live entries when they exist.
