### PR TITLE
Make sure that necessary JS is present to change button text

### DIFF
--- a/code/VersionedDataObjectDetailsForm.php
+++ b/code/VersionedDataObjectDetailsForm.php
@@ -3,6 +3,7 @@
 namespace Heyday\VersionedDataObjects;
 
 use Controller;
+use DataList;
 use FieldList;
 use Form;
 use FormAction;
@@ -11,10 +12,10 @@ use GridFieldDetailForm_ItemRequest;
 use HTMLText;
 use ManyManyList;
 use PjaxResponseNegotiator;
+use Requirements;
 use SS_HTTPResponse;
 use ValidationException;
 use ViewableData_Customised;
-use DataList;
 
 /**
  * Class VersionedDataObjectDetailsForm
@@ -39,6 +40,8 @@ class VersionedDataObjectDetailsForm_ItemRequest extends GridFieldDetailForm_Ite
      */
     public function ItemEditForm()
     {
+        Requirements::javascript(CMS_DIR.'/javascript/CMSMain.EditForm.js');
+
         VersionedReadingMode::setStageReadingMode();
 
         $form = parent::ItemEditForm();


### PR DESCRIPTION
I found that the JS needed to change the detail form's button text was not always being loaded for ModelAdmin views. It works if you navigate to the ModelAdmin after first loading a page that extends CMSMain because all CMSMain pages require `cmsmain.js`, a bundle that includes `CMSMain.EditForm.js`, which registers the event handlers that change button text when a data object is edited. However, if you directly access a ModelAdmin by URL or try to use the view after a full page refresh, this JS bundle is not required, and the button text won't change, i.e., the buttons always read "Saved" and "Published."

To alleviate this issue, I made sure that the necessary JS is always included whenever this module's detail form loads an ItemEditForm.